### PR TITLE
Specified more clearly the filenames to be used

### DIFF
--- a/P2JConvert_v2203.py
+++ b/P2JConvert_v2203.py
@@ -18,9 +18,9 @@ headerStringEnd_jmx = '              </collectionProp>             </HeaderManag
 itr_jmx = ''
 itr_final_jmx = ''
 
-########### Code  #########
+########### Code #########
 
-inputpath = input("Enter file path where postman collection is parked along with environment variables and/or global variables if defined : ")
+inputpath = input("Enter full directory path where Postman collection (collection.json) is parked along with environment variables (environment.json) and/or global variables (globals.json), if defined: ")
 #variablefile = input("If you have defined variables in postman, please export variables for the environment where you would like to run performance test and provide exported file path here, in case no variable defined just press Enter key\nEnter variables file path : ")
 
 # print(os.getcwd())
@@ -28,14 +28,15 @@ inputpath = input("Enter file path where postman collection is parked along with
 try:
     for i in os.listdir(inputpath):
          # print(i)
-         if "collection" in i:
+         if "collection.json" in i:
             inputfile = inputpath+"\\"+i
-         if "environment" in i:
+         if "environment.json" in i:
             variablefile = inputpath+"\\"+i
-         if "globals" in i:
+         if "globals.json" in i:
             globalvariablefile = inputpath+"\\"+i
 except Exception as e:
-    logging.error('Something went wrong with path provided, please verify path' + str(e))
+    logging.error('Something went wrong with provided path, please verify path ' + str(e))
+    logging.error('Please check that the filenames are exactly collection.json, environment.json, globals.json')
     sys.exit(1)
 
 dirname = os.path.dirname(inputfile)
@@ -50,7 +51,7 @@ try:
         filePart_2 = splitFile[1]
         # print(filePart_2)
 except Exception as e:
-    logging.error('Something went wrong while opening postman collection' + str(e))
+    logging.error('Something went wrong while opening Postman collection ' + str(e))
     sys.exit(1)
 
 findRequests = re.findall(r'{"name": "(.*?)",(.*?)"response"',filePart_2, re.DOTALL)
@@ -174,7 +175,7 @@ try:
 except Exception as e:
     logging.info('Either environment variables file not provided or something went wrong while opening it! ' + str(e))
 
-# global variables
+# Global Variables
 try:
     with open(globalvariablefile, 'r') as rf:
         FileContent = rf.read().replace('\n','')
@@ -207,5 +208,5 @@ try:
         wf.write(output)
         logging.info('Successfully created jmeter JMX file & Parked at location: ' +outfile)
 except Exception as e:
-    logging.error('Something went wrong while opening output file' + str(e))
+    logging.error('Something went wrong while opening output file ' + str(e))
     sys.exit()

--- a/README.md
+++ b/README.md
@@ -7,14 +7,15 @@ To verify python installation you can run "python -V" command in command prompt 
 
 ## How do I get set up?
 1. Clone the repository on your local system where python is installed.
-2. Verify requests are working as expected in postman.
-3. Export postman collection along with global and/or environment variables if any. Keep these exports in one folder.
-4. Run command in command line on your machine "python P2JConvert_v2203.py". It will return input prompt asking for path where exports are parked.
-5. Provide the path and press enter.
-6. In case of successful conversion, it should return successful message along with path to JMETER script.
+2. Verify requests are working as expected in Postman.
+3. Export Postman collection along with global and/or environment variables if any. Keep these exports in one folder.
+4. Rename Postman files respectively to `collection.json`, `environment.json`, `globals.json`.
+5. Run command in command line on your machine "python P2JConvert_v2203.py". It will return input prompt asking for path where exports are parked.
+6. Provide the full path and press enter.
+7. In case of successful conversion, it should return successful message along with path to JMETER script.
 
 ## Recommanded best practices to avoid issues. 
-1. Add headers explicitly even if same header is covered in hidden postman default header. Hidden headers will not be exported in collection hence need to add explicitly.
+1. Add headers explicitly even if same header is covered in hidden Postman default header. Hidden headers will not be exported in collection hence need to add explicitly.
 2. While exporting environment and global variables click on persist all otherwise it will export blank values.
 
  


### PR DESCRIPTION
With the current version of `PostmanToJMeterConvertor` the filenames have to be exactly:
- [`collection`](https://github.com/aniketaghodke/PostmanToJMeterConvertor/blob/72d5fe978aee9ce7dce59401554da25bd05efdb1/P2JConvert_v2203.py#L31)
- [`environment`](https://github.com/aniketaghodke/PostmanToJMeterConvertor/blob/72d5fe978aee9ce7dce59401554da25bd05efdb1/P2JConvert_v2203.py#L33)
- [`globals`](https://github.com/aniketaghodke/PostmanToJMeterConvertor/blob/72d5fe978aee9ce7dce59401554da25bd05efdb1/P2JConvert_v2203.py#L35)

I changed them respectively to `collection.json`, `environment.json`, `globals.json`, because Postman export them by default with a `.json` extension.

In addition, I specified more clearly the filenames to be used, both in the string provided to the user and in the README.